### PR TITLE
feat: Azure OpenAI対応を追加

### DIFF
--- a/llm_applications_library/llm/generators/openai_custom_generator.py
+++ b/llm_applications_library/llm/generators/openai_custom_generator.py
@@ -99,8 +99,9 @@ class RetryOpenAIGenerator:
                 api_key=self.api_key,
                 azure_endpoint=self.azure_endpoint,
                 api_version=self.azure_api_version,
+                max_retries=0,
             )
-        return openai.OpenAI(api_key=self.api_key)
+        return openai.OpenAI(api_key=self.api_key, max_retries=0)
 
     def _build_text_input(self, prompt: str, system_prompt: str | None = None):
         """Build Responses API input payload for text-only requests."""

--- a/llm_applications_library/llm/generators/openai_custom_generator.py
+++ b/llm_applications_library/llm/generators/openai_custom_generator.py
@@ -55,6 +55,7 @@ class RetryOpenAIGenerator:
     tenacityベースのretry機能を追加。
     OpenAI APIの一時的なエラー（レート制限、タイムアウト等）に対して
     指数バックオフでリトライを実行する。
+    Azure OpenAIもサポート。
     """
 
     def __init__(
@@ -62,18 +63,44 @@ class RetryOpenAIGenerator:
         api_key: str | None = None,
         model: str = "gpt-4o-mini",
         retry_config: RetryConfig | None = None,
+        azure_endpoint: str | None = None,
+        azure_api_version: str | None = None,
     ):
         """
         RetryOpenAIGeneratorを初期化
 
         Args:
-            api_key: OpenAI API key
-            model: OpenAI model name
-            retry_config: リトライ設定（RetryConfigオブジェクト）
+            api_key: OpenAI API key (Azure使用時はAzure APIキー)
+            model: OpenAI model name (Azure使用時はデプロイメント名)
+            retry_config: リトライ設定(RetryConfigオブジェクト)
+            azure_endpoint: Azure OpenAIエンドポイント(指定時はAzureモード)
+            azure_api_version: Azure OpenAI APIバージョン
         """
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.azure_endpoint = azure_endpoint or os.getenv("AZURE_OPENAI_ENDPOINT")
+        self.azure_api_version = (
+            azure_api_version
+            or os.getenv("AZURE_OPENAI_API_VERSION")
+            or "2024-12-01-preview"
+        )
+        self._use_azure = self.azure_endpoint is not None
+
+        if self._use_azure:
+            self.api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
+        else:
+            self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+
         self.model = model
         self.retry_config = retry_config or RetryConfig()
+
+    def _create_client(self) -> openai.OpenAI | openai.AzureOpenAI:
+        """OpenAIまたはAzure OpenAIクライアントを作成"""
+        if self._use_azure and self.azure_endpoint:
+            return openai.AzureOpenAI(
+                api_key=self.api_key,
+                azure_endpoint=self.azure_endpoint,
+                api_version=self.azure_api_version,
+            )
+        return openai.OpenAI(api_key=self.api_key)
 
     def _build_text_input(self, prompt: str, system_prompt: str | None = None):
         """Build Responses API input payload for text-only requests."""
@@ -134,7 +161,7 @@ class RetryOpenAIGenerator:
         @openai_retry(self.retry_config)
         def _run_with_retry():
             """retry機能付きのrun実行"""
-            client = openai.OpenAI(api_key=self.api_key)
+            client = self._create_client()
             input_payload = self._build_text_input(prompt, system_prompt)
 
             config_dict: dict[str, Any] = {}
@@ -178,17 +205,51 @@ class RetryOpenAIGenerator:
 
 
 class OpenAIVisionGenerator:
+    """Vision Generator with Azure OpenAI support."""
+
     def __init__(
-        self, model, api_key: str | None = None, retry_config: RetryConfig | None = None
+        self,
+        model: str,
+        api_key: str | None = None,
+        retry_config: RetryConfig | None = None,
+        azure_endpoint: str | None = None,
+        azure_api_version: str | None = None,
     ):
         self.model = model
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.azure_endpoint = azure_endpoint or os.getenv("AZURE_OPENAI_ENDPOINT")
+        self.azure_api_version = (
+            azure_api_version
+            or os.getenv("AZURE_OPENAI_API_VERSION")
+            or "2024-12-01-preview"
+        )
+        self._use_azure = self.azure_endpoint is not None
+
+        if self._use_azure:
+            self.api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
+        else:
+            self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+
         self.retry_config = retry_config or RetryConfig()
+
+    def _create_client(self) -> openai.OpenAI | openai.AzureOpenAI:
+        """OpenAIまたはAzure OpenAIクライアントを作成"""
+        if self._use_azure and self.azure_endpoint:
+            return openai.AzureOpenAI(
+                api_key=self.api_key,
+                azure_endpoint=self.azure_endpoint,
+                api_version=self.azure_api_version,
+                max_retries=0,
+                timeout=1800,
+            )
+        return openai.OpenAI(
+            api_key=self.api_key,
+            max_retries=0,
+            timeout=1800,
+        )
 
     def _chat_completion(
         self,
         messages: list[dict],
-        api_key: str | None = None,
         retry_config: RetryConfig | None = None,
         **generation_params: Any,
     ) -> dict[str, Any]:
@@ -196,18 +257,13 @@ class OpenAIVisionGenerator:
 
         Args:
             messages: Input messages for the API
-            api_key: OpenAI API key
             retry_config: Retry configuration
             **generation_params: Generation parameters (temperature, max_output_tokens, text, etc.)
         """
 
         @openai_retry(retry_config)
         def _make_api_call():
-            client = openai.OpenAI(
-                api_key=api_key or os.getenv("OPENAI_API_KEY"),
-                max_retries=0,
-                timeout=1800,
-            )
+            client = self._create_client()
 
             # Prepare Responses API parameters
             params = generation_params.copy()
@@ -384,7 +440,6 @@ class OpenAIVisionGenerator:
 
         response = self._chat_completion(
             messages=messages,
-            api_key=self.api_key,
             retry_config=retry_config_to_use,
             **filtered_params,
         )

--- a/llm_applications_library/llm/generators/schema.py
+++ b/llm_applications_library/llm/generators/schema.py
@@ -31,6 +31,9 @@ class APIKeySettings(BaseSettings):
     """API key settings from environment variables."""
 
     openai_api_key: str | None = None
+    azure_openai_api_key: str | None = None
+    azure_openai_endpoint: str | None = None
+    azure_openai_api_version: str | None = None
     anthropic_api_key: str | None = None
 
     model_config = {

--- a/tests/test_openai_custom_generator.py
+++ b/tests/test_openai_custom_generator.py
@@ -296,6 +296,7 @@ class TestAzureOpenAISupport:
                 api_key="azure-key",
                 azure_endpoint="https://test.openai.azure.com/",
                 api_version="2024-12-01-preview",
+                max_retries=0,
             )
             assert client == mock_client
 
@@ -312,7 +313,10 @@ class TestAzureOpenAISupport:
 
             client = generator._create_client()
 
-            mock_openai.assert_called_once_with(api_key="openai-key")
+            mock_openai.assert_called_once_with(
+                api_key="openai-key",
+                max_retries=0,
+            )
             assert client == mock_client
 
     def test_vision_generator_azure_initialization(self):
@@ -364,3 +368,23 @@ class TestAzureOpenAISupport:
             assert generator._use_azure is True
             assert generator.api_key == "env-azure-key"
             assert generator.azure_endpoint == "https://env-test.openai.azure.com/"
+
+    def test_vision_generator_creates_openai_client(self):
+        """OpenAIVisionGeneratorが標準OpenAIクライアントを作成するテスト"""
+        generator = OpenAIVisionGenerator(
+            model="gpt-4o",
+            api_key="openai-key",
+        )
+
+        with patch("openai.OpenAI") as mock_openai:
+            mock_client = Mock()
+            mock_openai.return_value = mock_client
+
+            client = generator._create_client()
+
+            mock_openai.assert_called_once_with(
+                api_key="openai-key",
+                max_retries=0,
+                timeout=1800,
+            )
+            assert client == mock_client

--- a/tests/test_openai_custom_generator.py
+++ b/tests/test_openai_custom_generator.py
@@ -253,13 +253,31 @@ class TestAzureOpenAISupport:
 
     def test_retry_generator_standard_openai_initialization(self):
         """RetryOpenAIGeneratorの標準OpenAI初期化テスト"""
-        generator = RetryOpenAIGenerator(
-            api_key="openai-key",
-            model="gpt-4o",
-        )
-        assert generator._use_azure is False
-        assert generator.api_key == "openai-key"
-        assert generator.azure_endpoint is None
+        import os
+
+        # 環境変数をクリアしてテストの安定性を確保
+        env_backup = {}
+        azure_vars = [
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_OPENAI_API_VERSION",
+        ]
+        for var in azure_vars:
+            env_backup[var] = os.environ.pop(var, None)
+
+        try:
+            generator = RetryOpenAIGenerator(
+                api_key="openai-key",
+                model="gpt-4o",
+            )
+            assert generator._use_azure is False
+            assert generator.api_key == "openai-key"
+            assert generator.azure_endpoint is None
+        finally:
+            # 環境変数を復元
+            for var, value in env_backup.items():
+                if value is not None:
+                    os.environ[var] = value
 
     def test_retry_generator_azure_env_vars(self):
         """RetryOpenAIGeneratorのAzure環境変数テスト"""

--- a/tests/test_openai_custom_generator.py
+++ b/tests/test_openai_custom_generator.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 from llm_applications_library.llm.generators.openai_custom_generator import (
     OpenAIVisionGenerator,
+    RetryOpenAIGenerator,
 )
 from llm_applications_library.llm.generators.schema import RetryConfig
 
@@ -232,3 +233,134 @@ class TestOpenAIVisionGenerator:
 
             assert call_kwargs["max_output_tokens"] == 500
             assert "max_tokens" not in call_kwargs
+
+
+class TestAzureOpenAISupport:
+    """Azure OpenAI対応のテスト"""
+
+    def test_retry_generator_azure_initialization(self):
+        """RetryOpenAIGeneratorのAzure初期化テスト"""
+        generator = RetryOpenAIGenerator(
+            api_key="azure-key",
+            model="gpt-4o",
+            azure_endpoint="https://test.openai.azure.com/",
+            azure_api_version="2024-12-01-preview",
+        )
+        assert generator._use_azure is True
+        assert generator.api_key == "azure-key"
+        assert generator.azure_endpoint == "https://test.openai.azure.com/"
+        assert generator.azure_api_version == "2024-12-01-preview"
+
+    def test_retry_generator_standard_openai_initialization(self):
+        """RetryOpenAIGeneratorの標準OpenAI初期化テスト"""
+        generator = RetryOpenAIGenerator(
+            api_key="openai-key",
+            model="gpt-4o",
+        )
+        assert generator._use_azure is False
+        assert generator.api_key == "openai-key"
+        assert generator.azure_endpoint is None
+
+    def test_retry_generator_azure_env_vars(self):
+        """RetryOpenAIGeneratorのAzure環境変数テスト"""
+        with patch.dict(
+            "os.environ",
+            {
+                "AZURE_OPENAI_ENDPOINT": "https://env-test.openai.azure.com/",
+                "AZURE_OPENAI_API_KEY": "env-azure-key",
+                "AZURE_OPENAI_API_VERSION": "2024-06-01",
+            },
+            clear=False,
+        ):
+            generator = RetryOpenAIGenerator(model="gpt-4o")
+            assert generator._use_azure is True
+            assert generator.api_key == "env-azure-key"
+            assert generator.azure_endpoint == "https://env-test.openai.azure.com/"
+            assert generator.azure_api_version == "2024-06-01"
+
+    def test_retry_generator_creates_azure_client(self):
+        """RetryOpenAIGeneratorがAzureOpenAIクライアントを作成するテスト"""
+        generator = RetryOpenAIGenerator(
+            api_key="azure-key",
+            model="gpt-4o",
+            azure_endpoint="https://test.openai.azure.com/",
+        )
+
+        with patch("openai.AzureOpenAI") as mock_azure:
+            mock_client = Mock()
+            mock_azure.return_value = mock_client
+
+            client = generator._create_client()
+
+            mock_azure.assert_called_once_with(
+                api_key="azure-key",
+                azure_endpoint="https://test.openai.azure.com/",
+                api_version="2024-12-01-preview",
+            )
+            assert client == mock_client
+
+    def test_retry_generator_creates_openai_client(self):
+        """RetryOpenAIGeneratorが標準OpenAIクライアントを作成するテスト"""
+        generator = RetryOpenAIGenerator(
+            api_key="openai-key",
+            model="gpt-4o",
+        )
+
+        with patch("openai.OpenAI") as mock_openai:
+            mock_client = Mock()
+            mock_openai.return_value = mock_client
+
+            client = generator._create_client()
+
+            mock_openai.assert_called_once_with(api_key="openai-key")
+            assert client == mock_client
+
+    def test_vision_generator_azure_initialization(self):
+        """OpenAIVisionGeneratorのAzure初期化テスト"""
+        generator = OpenAIVisionGenerator(
+            model="gpt-4o",
+            api_key="azure-key",
+            azure_endpoint="https://test.openai.azure.com/",
+            azure_api_version="2024-12-01-preview",
+        )
+        assert generator._use_azure is True
+        assert generator.api_key == "azure-key"
+        assert generator.azure_endpoint == "https://test.openai.azure.com/"
+
+    def test_vision_generator_creates_azure_client(self):
+        """OpenAIVisionGeneratorがAzureOpenAIクライアントを作成するテスト"""
+        generator = OpenAIVisionGenerator(
+            model="gpt-4o",
+            api_key="azure-key",
+            azure_endpoint="https://test.openai.azure.com/",
+        )
+
+        with patch("openai.AzureOpenAI") as mock_azure:
+            mock_client = Mock()
+            mock_azure.return_value = mock_client
+
+            client = generator._create_client()
+
+            mock_azure.assert_called_once_with(
+                api_key="azure-key",
+                azure_endpoint="https://test.openai.azure.com/",
+                api_version="2024-12-01-preview",
+                max_retries=0,
+                timeout=1800,
+            )
+            assert client == mock_client
+
+    def test_vision_generator_azure_env_vars(self):
+        """OpenAIVisionGeneratorのAzure環境変数テスト"""
+        with patch.dict(
+            "os.environ",
+            {
+                "AZURE_OPENAI_ENDPOINT": "https://env-test.openai.azure.com/",
+                "AZURE_OPENAI_API_KEY": "env-azure-key",
+            },
+            clear=False,
+        ):
+            generator = OpenAIVisionGenerator(model="gpt-4o")
+            assert generator._use_azure is True
+            assert generator.api_key == "env-azure-key"
+            assert generator.azure_endpoint == "https://env-test.openai.azure.com/"


### PR DESCRIPTION
## 概要

RetryOpenAIGeneratorとOpenAIVisionGeneratorにAzure OpenAIサポートを追加しました。

## 変更内容

- `azure_endpoint` と `azure_api_version` パラメータを追加
- 環境変数 `AZURE_OPENAI_ENDPOINT` が設定されている場合は自動的にAzureモードに切り替え
- `_create_client()` メソッドで `openai.AzureOpenAI` または `openai.OpenAI` を適切に選択
- `APIKeySettings` に Azure用環境変数を追加
- Azure OpenAI クライアント作成のユニットテストを追加（8テストケース）

## 使用方法

### 標準OpenAI（変更なし）
```python
generator = RetryOpenAIGenerator(api_key="sk-...", model="gpt-4o")
```

### Azure OpenAI
```python
generator = RetryOpenAIGenerator(
    model="gpt-4o",  # デプロイメント名
    azure_endpoint="https://your-resource.openai.azure.com/",
    azure_api_version="2024-12-01-preview"
)
```

### 環境変数経由
```bash
export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
export AZURE_OPENAI_API_KEY="your-key"
export AZURE_OPENAI_API_VERSION="2024-12-01-preview"
```

```python
# 環境変数が設定されていれば自動的にAzureモードになる
generator = RetryOpenAIGenerator(model="gpt-4o")
```

## テスト計画

- [x] 既存テスト通過確認（tox）
- [x] Azure OpenAI初期化テスト
- [x] 環境変数からのAzure設定読み込みテスト
- [x] Azure/OpenAIクライアント作成テスト
- [x] 疎通テスト（gpt-4o, gpt-5.1, gpt-5.2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Azure OpenAI の選択的サポートを追加し、標準/OpenAI 両バックエンドで生成と Vision フローが動作します。
* **設定**
  * 環境変数から Azure エンドポイント、API バージョン、Azure 用 API キーを読み取れるようになりました。
* **テスト**
  * Azure 対応と環境変数ベース設定を検証する包括的なテストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->